### PR TITLE
Fix: #AR-8986 ca-sdk-example readme update for codesandbox in SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-# Vue 3 + TypeScript + Vite
+# CA-SDK: Sample Integration 
 
-This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+This repository contains sources of a typical Vue3 + TypeScript + Vite sample application that integrates with the Arcana CA SDK.
 
-Learn more about the recommended Project Setup and IDE Support in the [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).
+This sample app is generated using the Vue 3 `<script setup>` SFCs. Check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more. For details about the recommended project setup and IDE support, see [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).
+
+The following files were updated in the original sample code to integrate with the CA SDK:
+
+* src/App.vue
+* src/utils/getCA.ts
+* src/components/Transfer.vue
+* src/components/PreLogin.vue
+* src/components/BalanceSidebar.vue
+
+Use the CA SDK [Quick Start Guide](https://docs.arcana.network/quick-start/ca-quick-start/), [SDK Reference Guide](https://ca-sdk-ref-guide.netlify.app/) and the [Usage Guide](https://docs.arcana.network/ca/ca-usage-guide/) for details.


### PR DESCRIPTION
This Readme is the first thing that shows up when a developer clicks 'try now' in the CA SDK docs landing page.

It should show relevant info on how this sample can help them get started 0->1 with SDK integration instead of canned README content.

Pls review and approve.